### PR TITLE
Bugfixes: Sum of components did not add up to total in diet output 

### DIFF
--- a/src/lib/diet-output-generator.test.ts
+++ b/src/lib/diet-output-generator.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect } from "vitest";
+import ResultsEngine from "./ResultsEngine";
+import * as Parsers from "./input-files-parsers";
+
+import emissionsFactorsEnergyCsv from "@/default-input-files/SAFAD IEF Energy.csv?raw";
+import emissionsFactorsPackagingCsv from "@/default-input-files/SAFAD IEF Packaging.csv?raw";
+import emissionsFactorsTransportCsv from "@/default-input-files/SAFAD IEF Transport.csv?raw";
+import processesEnergyDemandsCsv from "@/default-input-files/SAFAD IP Energy Proc.csv?raw";
+import preparationProcessesCsv from "@/default-input-files/SAFAD IP Preparation Processes.csv?raw";
+import packagingCodesCsv from "@/default-input-files/SAFAD IP Packaging.csv?raw";
+import footprintsRpcsCsv from "@/default-input-files/SAFAD ID Footprints RPC.csv?raw";
+import foodsRecipesCsv from "@/default-input-files/SAFAD IP Recipes.csv?raw";
+import wasteRetailAndConsumerCsv from "@/default-input-files/SAFAD IP Waste Retail and Cons/SAFAD IP Waste Retail and Cons SE.csv?raw";
+import dietCsv from "@/default-input-files/SAFAD ID Diet Spec/SAFAD ID Diet Spec SE.csv?raw";
+import rpcOriginWasteCsv from "@/default-input-files/SAFAD IP Origin and Waste of RPC/SAFAD IP Origin and Waste of RPC SE.csv?raw";
+
+import {
+  DIET_RESULTS_HEADER,
+  computeDietFootprints,
+} from "./diet-output-generator";
+import { extractRpcNamesFromRecipe } from "./efsa-names";
+import { AGGREGATE_HEADERS } from "./impacts-csv-utils";
+import { toNamespacedPath } from "path";
+
+const emissionsFactorsPackaging = Parsers.parseEmissionsFactorsPackaging(
+  emissionsFactorsPackagingCsv
+);
+const emissionsFactorsEnergy = Parsers.parseEmissionsFactorsEnergy(
+  emissionsFactorsEnergyCsv
+);
+const emissionsFactorsTransport = Parsers.parseEmissionsFactorsTransport(
+  emissionsFactorsTransportCsv
+);
+const processesEnergyDemands = Parsers.parseProcessesEnergyDemands(
+  processesEnergyDemandsCsv
+);
+const preparationProcesses = Parsers.parsePreparationProcesses(
+  preparationProcessesCsv
+);
+const packagingCodes = Parsers.parsePackagingCodes(packagingCodesCsv);
+const footprintsRpcs = Parsers.parseFootprintsRpcs(footprintsRpcsCsv);
+const foodsRecipes = Parsers.parseFoodsRecipes(foodsRecipesCsv);
+const wasteRetailAndConsumer = Parsers.parseWasteRetailAndConsumer(
+  wasteRetailAndConsumerCsv
+);
+const rpcOriginWaste = Parsers.parseRpcOriginWaste(rpcOriginWasteCsv);
+
+describe("diet-output-generator.ts", async () => {
+  const RE = new ResultsEngine();
+  const efsaNames = extractRpcNamesFromRecipe(foodsRecipesCsv);
+
+  RE.setCountryCode("SE");
+
+  RE.setEmissionsFactorsPackaging(emissionsFactorsPackaging);
+  RE.setEmissionsFactorsEnergy(emissionsFactorsEnergy);
+  RE.setEmissionsFactorsTransport(emissionsFactorsTransport);
+  RE.setProcessesEnergyDemands(processesEnergyDemands);
+  RE.setPreparationProcesses(preparationProcesses);
+  RE.setPackagingCodes(packagingCodes);
+  RE.setFootprintsRpcs(footprintsRpcs);
+  RE.setFoodsRecipes(foodsRecipes);
+  RE.setWasteRetailAndConsumer(wasteRetailAndConsumer);
+  RE.setRpcOriginWaste(rpcOriginWaste);
+
+  describe("Diet output for Margarin", () => {
+    const diet: Diet = [["A.11.06.001", 1000]];
+    const rows = computeDietFootprints(diet, RE, efsaNames);
+    const amounts = RE.reduceDiet(diet);
+    const rpcAmounts = Object.fromEntries(amounts[0]);
+    const componentRows = rows.filter((r) => r[2] === "Component");
+
+    // Sanity-check: the amounts in the rows match the reduceDiet output
+    test("Amounts in rows match output from reduceDietToRpcs", () => {
+      componentRows.forEach((row) => {
+        const subcode = row[3];
+        if (!subcode) return;
+        const amount = Number.parseFloat(row[7]);
+        expect(amount).toBeCloseTo(rpcAmounts[subcode]);
+        const pDeviation =
+          Math.abs(rpcAmounts[subcode] - amount) / rpcAmounts[subcode];
+        expect(pDeviation).toBeLessThan(0.02);
+      });
+    });
+
+    test("Column sums match", () => {
+      const startLabel = AGGREGATE_HEADERS[0];
+      const endLabel = AGGREGATE_HEADERS[AGGREGATE_HEADERS.length - 1];
+      const startIdx = DIET_RESULTS_HEADER.indexOf(startLabel);
+      const endIdx = DIET_RESULTS_HEADER.indexOf(endLabel);
+
+      for (let colIdx = startIdx; colIdx <= endIdx; colIdx++) {
+        const totalValue = Number.parseFloat(rows[0][colIdx]);
+        const computedSum = componentRows
+          .map((row) => Number.parseFloat(row[colIdx]))
+          .reduce((a, b) => a + b, 0);
+
+        if (totalValue === 0) {
+          expect(
+            totalValue,
+            "Mismatch for column: " + DIET_RESULTS_HEADER[colIdx]
+          ).toEqual(computedSum);
+        } else {
+          const pDeviation = Math.abs(totalValue - computedSum) / totalValue;
+          expect(
+            pDeviation,
+            "Mismatch for column: " + DIET_RESULTS_HEADER[colIdx]
+          ).toBeLessThan(0.01);
+        }
+      }
+    });
+  });
+});

--- a/src/lib/diet-output-generator.ts
+++ b/src/lib/diet-output-generator.ts
@@ -9,7 +9,7 @@ export const DIET_RESULTS_HEADER = [
   "Food-product Name",
   "Total or component",
   ...DETAILED_RESULTS_HEADER,
-];
+] as const;
 
 export const computeDietFootprints = (
   diet: Diet,

--- a/src/lib/diet-output-generator.ts
+++ b/src/lib/diet-output-generator.ts
@@ -24,7 +24,7 @@ export const computeDietFootprints = (
       // First, compute the impact of each diet element seperately
       const ingredientRows: string[][] = rpcAmounts
         .map(([subcode, subamount]) => {
-          const impacts = RE.computeImpacts([[subcode, subamount]]);
+          const impacts = RE.computeImpacts([[subcode, subamount]], false);
           const filteredImpacts = [
             impacts[0],
             {},

--- a/src/lib/diet-output-generator.ts
+++ b/src/lib/diet-output-generator.ts
@@ -25,11 +25,18 @@ export const computeDietFootprints = (
       const ingredientRows: string[][] = rpcAmounts
         .map(([subcode, subamount]) => {
           const impacts = RE.computeImpacts([[subcode, subamount]]);
+          const filteredImpacts = [
+            impacts[0],
+            {},
+            {},
+            {},
+          ] satisfies ImpactsTuple;
+
           return [
             code,
             name,
             "Component",
-            ...labeledImpacts(subcode, subamount, impacts, efsaNames),
+            ...labeledImpacts(subcode, subamount, filteredImpacts, efsaNames),
           ];
         })
         .filter((x): x is string[] => x !== null);
@@ -39,18 +46,33 @@ export const computeDietFootprints = (
       const totalImpacts = RE.computeImpacts([[code, amount]]);
       if (totalImpacts === null) return null;
 
-      const processesImpactsRow = labeledImpacts(
-        "Processes",
-        amount,
-        [{}, totalImpacts[1], {}, {}],
-        efsaNames
-      );
-      const packagingImpactsRow = labeledImpacts(
-        "Packaging",
-        amount,
-        [{}, {}, totalImpacts[2], {}],
-        efsaNames
-      );
+      const createRow = (impactsIdx: 1 | 2 | 3, category: string) => {
+        const impactsTuple: ImpactsTuple = [
+          {},
+          impactsIdx === 1 ? totalImpacts[1] : {},
+          impactsIdx === 2 ? totalImpacts[2] : {},
+          impactsIdx === 3 ? totalImpacts[3] : {},
+        ];
+
+        const impactsRow = labeledImpacts(
+          category,
+          amount,
+          impactsTuple,
+          efsaNames
+        );
+
+        return [
+          code,
+          category,
+          "Component",
+          "",
+          category,
+          "Processes, packaging and transport",
+          "Processes, packaging and transport",
+          "",
+          ...impactsRow.slice(5),
+        ];
+      };
 
       return [
         [
@@ -60,8 +82,9 @@ export const computeDietFootprints = (
           ...labeledImpacts(code, amount, totalImpacts, efsaNames),
         ],
         // drop names and amount for processing and packaging rows
-        [code, name, "Component", "", "Processes", "Processes and packaging", "Processes and packaging", "", ...processesImpactsRow.slice(5)],
-        [code, name, "Component", "", "Packaging", "Processes and packaging", "Processes and packaging", "", ...packagingImpactsRow.slice(5)],
+        createRow(1, "Processes"),
+        createRow(2, "Packaging"),
+        createRow(3, "Transport"),
         ...ingredientRows,
       ];
     })

--- a/src/lib/input-files-parsers.test.ts
+++ b/src/lib/input-files-parsers.test.ts
@@ -9,7 +9,7 @@ import preparationProcessesCsv from "@/default-input-files/SAFAD IP Preparation 
 import packagingCodesCsv from "@/default-input-files/SAFAD IP Packaging.csv?raw";
 import footprintsRpcsCsv from "@/default-input-files/SAFAD ID Footprints RPC.csv?raw";
 import foodsRecipesCsv from "@/default-input-files/SAFAD IP Recipes.csv?raw";
-import sfaRecipesCsv from "@/default-input-files/SAFAD IS SFA Recipes.csv?raw";
+import sfaRecipesCsv from "@/default-input-files/SAFAD IP SFA Recipes.csv?raw";
 import wasteRetailAndConsumerCsv from "@/default-input-files/SAFAD IP Waste Retail and Cons/SAFAD IP Waste Retail and Cons SE.csv?raw";
 import dietCsv from "@/default-input-files/SAFAD ID Diet Spec/SAFAD ID Diet Spec SE.csv?raw";
 import rpcOriginWasteCsv from "@/default-input-files/SAFAD IP Origin and Waste of RPC/SAFAD IP Origin and Waste of RPC SE.csv?raw";


### PR DESCRIPTION
Two errors were at hand, that have now been fixed.

1. We had forgotten that the waste (consumer and retail) will differ if you compute the impacts of commodities directly, or from the entire product. For example, an apple pie has different waste factors than the apple in the pie itself.
2. When computing the transport emissions directly on the ingredients, we get different results than when directly on the food-product (the total). 

Fixes:
1. Let `ResultsEngine.computeImpacts` accept a `withWaste = true | false` parameter.
2. Separate the transports, like we did with processes and packaging.